### PR TITLE
Set base container version to better model local package install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:0.12.4
+FROM node:slim
 
 COPY inventoryService.js /src/ 
 WORKDIR /src
 
 RUN npm install redis
-CMD ["node", "inventoryService.js"]
+CMD ["nodejs", "inventoryService.js"]


### PR DESCRIPTION
Set base container version to better model local package install, otherwise the example look like the containerization requires a change.
